### PR TITLE
Compose

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-version: '3.7'
+version: '3.8'
 services:
   # Update this to the name of the service you want to work with in your docker-compose.yml file
   phpunit:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@
 version: '3.7'
 services:
   database:
-    container_name: database
     environment:
       MYSQL_ROOT_PASSWORD: examplepass
     image: mysql:${MYSQL_VERSION:-5.7}
@@ -10,7 +9,6 @@ services:
   phpunit:
     command:
       - bash
-    container_name: phpunit
     depends_on:
       - database
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '3.7'
+version: '3.8'
 services:
   database:
     environment:


### PR DESCRIPTION
- Remove container name from Compose file
- Update Compose file version

## Remove container name from Compose file

Since the command `docker-compose exec` is available
instead of the `command docker exec`.
The command `docker-compose exec` can specify target by service name
instead of container name.

cf.

- [docker-compose exec | Docker Documentation](https://docs.docker.com/compose/reference/exec/)
- [docker exec | Docker Documentation](https://docs.docker.com/engine/reference/commandline/exec/)