### PR TITLE
Change path to Compose file as UNIX style

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
 	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
 	"dockerComposeFile": [
-		"..\\docker-compose.yml",
+		"../docker-compose.yml",
 		"docker-compose.yml"
 	],
 


### PR DESCRIPTION
Since current recommended usage of Docker Desktop in Windows is not
from Windows but from WSL.